### PR TITLE
realpathはansibleを動かしてるマシンで動くのでサーバとズレる

### DIFF
--- a/vars/main.yml
+++ b/vars/main.yml
@@ -114,8 +114,8 @@ nginxv3_defaults_conf_http:
   - { key: "brotli_min_length", value: "1024" }
   - { key: "brotli_comp_level", value: "6" }
   - { key: "open_file_cache", value: "max=1000000" }
-  - { key: "include", value: "{{ nginxv3_conf_dir | realpath }}/*.conf", merge_mode: "append" }
   - { key: "vhost_traffic_status_zone", value: "" }
+  - { key: "include", value: "{{ nginxv3_conf_dir }}/*.conf", merge_mode: "append" }
 nginxv3_merged_conf_http: >-
   {{ (nginxv3_defaults_conf_http + nginxv3_conf_http) | combine_dict_list }}
 


### PR DESCRIPTION
表題の通りです。

macで流し込むと "{{ "/etc/nginx/conf.d" | realpath }}"が"/private/etc/nginx/conf.d"になってしまいました。どうやら、templateが実行されるのはansible-playbookを実行しているマシンなのでそういう結果になるっぽいです。

base-ansibleの方にもあとで似たようなプルリクを投げると思います、よろしくおねがいします。
